### PR TITLE
sort SpaceObjects according to z-index

### DIFF
--- a/src/js/Starfield.DeepSpaceLayer.js
+++ b/src/js/Starfield.DeepSpaceLayer.js
@@ -18,6 +18,7 @@ define('Starfield.DeepSpaceLayer', [
         this.generateSpaceObjects(new BackgroundCloudGenerator(this.game));
         this.generateSpaceObjects(new PlanetGenerator(this.game));
         this.generateSpaceObjects(new MeteoritesGenerator(this.game));
+        this.sortSpaceObjects();
     }
 
     DeepSpaceLayer.prototype = {
@@ -50,6 +51,12 @@ define('Starfield.DeepSpaceLayer', [
                 this.addSpaceObject(so);
             }.bind(this));
         },
+
+        sortSpaceObjects: function() {
+            this.spaceObject.sort(function(a, b){
+                return return b.z - a.z;
+            });
+        }
 
         addSpaceObject: function(spaceObject) {
             if (!spaceObject) return;


### PR DESCRIPTION
#### Intent
To sort SpaceObjects according to their z-index in order to generate three-dimensional effect

#### Solution
- SpaceObject instances weren't properly sorted after being added to the collection in DeepSpaceLayer. This fix makes triggers the native ```sort``` function against the array.