### PR TITLE
Feature/368

### DIFF
--- a/src/js/effects/EffectManager.js
+++ b/src/js/effects/EffectManager.js
@@ -139,12 +139,9 @@ class EffectManager {
       // calculates the offset according to the weapon's parent entity
       const emitter = effect.getEmitter();
       if (emitter instanceof Weapon) {
-        const emitterDataObject = emitter
-          .getManager()
-          .getEntity()
-          .getDataObject();
+        const emitterEntity = emitter.getManager().getEntity();
         const projectileOffset =
-          (emitterDataObject && emitterDataObject.getProjectileOffset()) || {};
+          (emitterEntity && emitterEntity.getProjectileOffsetByHeading()) || {};
         offsetX = projectileOffset.x || 0;
         offsetY = projectileOffset.y || 0;
       }

--- a/src/js/entities/Entity.js
+++ b/src/js/entities/Entity.js
@@ -876,6 +876,19 @@ class Entity {
   getCreationTime() {
     return this.createdAt;
   }
+
+  /**
+   * Returns the horizontal and vertical offset of the particles
+   * emitted by the entity so that they appear on the right
+   * position according to the current heading of the entity object
+   * @return {object} - {x, y}
+   */
+  getProjectileOffsetByHeading() {
+    const projectileOffset = this.dataObject.getProjectileOffset();
+    if (!projectileOffset.length) return projectileOffset;
+    const angleCode = this.motionManager.getCurrentAngleCode();
+    return projectileOffset[angleCode] || {};
+  }
 }
 
 export default Entity;

--- a/src/js/entities/weapons/Weapon.js
+++ b/src/js/entities/weapons/Weapon.js
@@ -90,8 +90,7 @@ class Weapon {
 
   fire(targetEntity) {
     const targetSprite = targetEntity.getSprite();
-    const dataObject = this.entity.getDataObject();
-    const projectileOffset = dataObject.getProjectileOffset();
+    const projectileOffset = this.entity.getProjectileOffsetByHeading();
     const sprite = this.entity.getSprite();
     const distance = Util.distanceBetweenSprites(sprite, targetSprite);
 

--- a/src/js/map/Map.js
+++ b/src/js/map/Map.js
@@ -165,6 +165,10 @@ class Map {
   getGame() {
     return game;
   }
+
+  getStarfield() {
+    return starfield;
+  }
 }
 
 export default Map;


### PR DESCRIPTION
## Prelude
Hotfix for making the projectiles appear in front of the entities based on the actual heading must be merged to master.

## Issue
#368

## Solution
Use InitialPoint defined in Entity DataObject according to the actual heading of the given entity.

## Test
Manual test 
