### PR TITLE
Feature/353

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "",
   "readme": "",
   "repository": "",
-  "version": "0.41.5",
+  "version": "0.41.6",
   "dependencies": {
     "ansi-regex": "^3.0.0",
     "easystarjs": "^0.4.1",

--- a/src/js/common/Graphics.js
+++ b/src/js/common/Graphics.js
@@ -16,6 +16,7 @@ function createGraphicsInstance() {
     'energy-shields',
     'effects',
     'prior-gui-elements',
+    'starfield-foreground',
     'fogofwar',
     'gui',
     'tooltips',

--- a/src/js/starfield/Foreground.js
+++ b/src/js/starfield/Foreground.js
@@ -5,13 +5,12 @@ import Graphics from '../common/Graphics';
 const ns = window.fivenations;
 let sprites;
 
-class DeepSpaceLayer {
+class Foreground {
   constructor(map, generator) {
     this.setMap(map);
     this.setGame(map.getGame());
     this.createTexture();
     this.createContainer();
-    this.addContainerToStarfieldGroup();
     this.createSprites();
     this.createSpaceObjects(generator);
   }
@@ -43,21 +42,23 @@ class DeepSpaceLayer {
   createContainer() {
     this.container = this.game.add.image(0, 0, this.texture);
     this.container.fixedToCamera = true;
-  }
-
-  addContainerToStarfieldGroup() {
-    this.group = Graphics.getInstance().getGroup('starfield');
+    this.group = Graphics.getInstance().getGroup('starfield-foreground');
     this.group.add(this.container);
   }
 
   createSprites() {
     if (sprites) return;
     sprites = {
-      cloud1: this.game.make.sprite(0, 0, 'starfield.clouds.bg.type-1'),
-      cloud2: this.game.make.sprite(0, 0, 'starfield.clouds.bg.type-2'),
-      meteorites: this.game.make.sprite(0, 0, 'starfield.meteorites'),
-      planet1: this.game.make.sprite(0, 0, 'starfield.planets.type-1'),
-      planet2: this.game.make.sprite(0, 0, 'starfield.planets.type-2'),
+      cloud1: this.game.make.sprite(
+        0,
+        0,
+        'starfield.foregound.foreground.type-1',
+      ),
+      cloud2: this.game.make.sprite(
+        0,
+        0,
+        'starfield.foregound.foreground.type-2',
+      ),
     };
   }
 
@@ -106,4 +107,4 @@ class DeepSpaceLayer {
   }
 }
 
-export default DeepSpaceLayer;
+export default Foreground;

--- a/src/js/starfield/ForegroundCloudGenerator.js
+++ b/src/js/starfield/ForegroundCloudGenerator.js
@@ -1,0 +1,43 @@
+import SpaceObject from './SpaceObject';
+import SpaceObjectGenerator from './SpaceObjectGenerator';
+import Util from '../common/Util';
+
+const MAX_NUMBER_OF_CLOUDS = 100;
+
+class ForegroundCloudGenerator extends SpaceObjectGenerator {
+  generate(density) {
+    this.createClouds(density);
+  }
+
+  createClouds(density = 1) {
+    const max = Math.floor(MAX_NUMBER_OF_CLOUDS * density);
+    for (let i = 0; i < max; i += 1) {
+      this.createRandomizedCloud();
+    }
+  }
+
+  createRandomizedCloud() {
+    const map = this.deepSpaceLayer.getMap();
+    const sprites = this.deepSpaceLayer.getSprites();
+    const NUMBER_OF_TYPES = 2;
+    const NUMBER_OF_FRAMES = 4;
+    const type = Util.rnd(1, NUMBER_OF_TYPES);
+    const sprite = sprites[`cloud${type}`];
+    const z = Math.random() + 1;
+    const x = Math.floor(Util.rnd(0, map.getScreenWidth()) * z);
+    const y = Math.floor(Util.rnd(0, map.getScreenHeight()) * z);
+    const frame = Util.rnd(0, NUMBER_OF_FRAMES - 1);
+    const scale = Util.rnd(75, 125) / 100;
+
+    const cloud = new SpaceObject(sprite)
+      .setX(x)
+      .setY(y)
+      .setZ(z)
+      .setScale(scale)
+      .setFrame(frame);
+
+    this.addSpaceObject(cloud);
+  }
+}
+
+export default ForegroundCloudGenerator;

--- a/src/js/starfield/Starfield.js
+++ b/src/js/starfield/Starfield.js
@@ -3,12 +3,14 @@ import SpaceObjectGenerator from './SpaceObjectGenerator';
 import PlanetAreaGenerator from './PlanetAreaGenerator';
 import DeepSpaceLayer from './DeepSpaceLayer';
 import Background from './Background';
+import Foreground from './Foreground';
 
 class Starfield {
   constructor(map, config = {}) {
     this.initLayers();
     this.createBackground(map, config.backgroundTile);
     this.createDeepSpaceObjects(map, config.starfieldGenerator);
+    this.createForegoundObjects(map, config.foregroundGenerator);
   }
 
   initLayers() {
@@ -23,7 +25,12 @@ class Starfield {
     this.layers.push(new DeepSpaceLayer(map, generator));
   }
 
+  createForegroundObjects(map, generator) {
+    this.layers.push(new Foreground(map, generator));
+  }
+
   resetLayers() {
+    // @TODO This is obviously not enough to avoid leaking
     this.layers.splice();
   }
 

--- a/src/js/starfield/Starfield.js
+++ b/src/js/starfield/Starfield.js
@@ -1,6 +1,7 @@
 import SpaceObject from './SpaceObject';
 import SpaceObjectGenerator from './SpaceObjectGenerator';
 import PlanetAreaGenerator from './PlanetAreaGenerator';
+import ForegroundCloudGenerator from './ForegroundCloudGenerator';
 import DeepSpaceLayer from './DeepSpaceLayer';
 import Background from './Background';
 import Foreground from './Foreground';
@@ -10,7 +11,7 @@ class Starfield {
     this.initLayers();
     this.createBackground(map, config.backgroundTile);
     this.createDeepSpaceObjects(map, config.starfieldGenerator);
-    this.createForegoundObjects(map, config.foregroundGenerator);
+    this.createForegroundObjects(map, config.foregroundGenerator);
   }
 
   initLayers() {
@@ -44,5 +45,6 @@ class Starfield {
 Starfield.SpaceObject = SpaceObject;
 Starfield.SpaceObjectGenerator = SpaceObjectGenerator;
 Starfield.PlanetAreaGenerator = PlanetAreaGenerator;
+Starfield.ForegroundCloudGenerator = ForegroundCloudGenerator;
 
 export default Starfield;

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -185,6 +185,7 @@
           starfield: {
             backgroundTile: 'starfield-1',
             starfieldGenerator: Starfield.PlanetAreaGenerator,
+            foregroundGenerator: Starfield.ForegroundCloudGenerator,
           }
         });
 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -168,6 +168,7 @@
       var app = new FiveNations({ canvasElmId: 'fivenations-game' });
       var scriptBox = FiveNations.Scriptbox.getInstance();
       scriptBox.add('default', function(game) {
+        var Starfield = game.map.Starfield;
 
         window.addEntity = function(id, team, x, y) {
           game.eventEmitter.synced.entities.add({
@@ -178,13 +179,12 @@
           });
         };
 
-        var Starfield = game.map.Starfield;
         game.map.new({
           width: 96,
           height: 96,
           starfield: {
             backgroundTile: 'starfield-1',
-            starfieldGenerator: Starfield.PlanetAreaGenerator
+            starfieldGenerator: Starfield.PlanetAreaGenerator,
           }
         });
 


### PR DESCRIPTION
## Prelude
Foreround layer must be added to the Starfield layer to improve the fake 3d effect. 

## Issue
#353 

## Solution
- Foreground objects are handled by a separate self-contained Layer object
- Generators can be added to specify how the foreground objects appear on the game scene.

## Test
Manual test

