### PR TITLE
fix followTarget behaviour

### DIFF
--- a/src/js/effects/EffectManager.js
+++ b/src/js/effects/EffectManager.js
@@ -334,7 +334,14 @@ class EffectManager {
       sprite = effect.getSprite();
       targetSprite = targetEntity.getSprite();
 
-      if (sprite.body.speed >= sprite.body.maxVelocity.x) {
+      if (
+        !effect._isHomingModeActivated &&
+        sprite.body.speed >= sprite.body.maxVelocity.x
+      ) {
+        effect._isHomingModeActivated = true;
+      }
+
+      if (effect._isHomingModeActivated) {
         rotation = phaserGame.physics.arcade.angleBetween(sprite, targetSprite);
 
         if (sprite.rotation !== rotation) {


### PR DESCRIPTION
## Prelude
`followTarget` activity for effects doesn't work as expected. It always rotates only 90 degrees to the given direction.

## Issue
#386 

## Solution
- Removed real-time calculation of the speed to trigger the `followTarget` behaviour. It now activates once the effect reaches its MaxVelocity and remains active since. 

## Test
Manual tests