### PR TITLE
#446 Add ability to turn without stopping for slow units

### DIFF
--- a/src/js/common/Util.js
+++ b/src/js/common/Util.js
@@ -23,6 +23,19 @@ export default {
     },
 
     /**
+     * Returns the difference between the given radial numbers based on the
+     * passed maximum value. (Example.: angle codes or angles)
+     * @param {number} a
+     * @param {number} b
+     * @param {number} max
+     * @return {number}
+     */
+    getDiffBetweenRadialValues: function(a, b, max) {
+        const m = max / 2;
+        return m - Math.abs(Math.abs(a - b) - m); 
+    },
+
+    /**
      * returns whether the given value is numeric or not
      * @param {mixed} val 
      */

--- a/src/js/entities/activities/GetInRange.js
+++ b/src/js/entities/activities/GetInRange.js
@@ -68,14 +68,7 @@ class GetInRange extends Move {
    * @return {void}
    */
   activate() {
-    const sprite = this.target.getSprite();
-    const x = sprite.x;
-    const y = sprite.y;
-    this.setCoords({
-      x,
-      y,
-    });
-
+    this.setCoordsToTarget();
     super.activate();
   }
 
@@ -91,15 +84,30 @@ class GetInRange extends Move {
       return;
     }
 
+    this.setCoordsToTarget();
     this.entity.getMotionManager().moveTo(this);
   }
 
   /**
    * Saving the target entity that will be followed
-   * @oaram {object} entity - Entity
+   * @param {object} entity - Entity
    */
   setTarget(entity) {
     this.target = entity;
+  }
+
+  /**
+   * Updates the coords object with the coordinates of the given
+   * target Entity
+   */
+  setCoordsToTarget() {
+    const sprite = this.target.getSprite();
+    const x = sprite.x;
+    const y = sprite.y;
+    this.setCoords({
+      x,
+      y,
+    });
   }
 
   /**

--- a/src/js/entities/motions/MotionManager.js
+++ b/src/js/entities/motions/MotionManager.js
@@ -371,7 +371,13 @@ MotionManager.prototype = {
    * @return {void}
    */
   updateRotation() {
-    if (this.isMoving() && this.entity.hasSlowManeuverability()) {
+    // when entities with slow manouver ability are moving but not
+    // facing the target closely
+    if (
+      this.isMoving() &&
+      this.entity.hasSlowManeuverability() &&
+      !this.isEntityFacingTargetRoughly()
+    ) {
       return;
     }
 
@@ -603,6 +609,23 @@ MotionManager.prototype = {
   },
 
   /**
+   * Returns if the entity is headed more or less towards its target.
+   * This is used to prevent entities to stop every time when the
+   * angle between them and their targets differ
+   * @return {boolean} true if the diff between the angleCodes is less then 90 degrees
+   */
+  isEntityFacingTargetRoughly() {
+    const { targetAngleCode, currentAngleCode, maxAngleCount } = this.rotation;
+    const diff = Util.getDiffBetweenRadialValues(
+      targetAngleCode,
+      currentAngleCode,
+      maxAngleCount,
+    );
+    const treshold = Math.floor(maxAngleCount / 4); // one quarter of a round
+    return diff < treshold;
+  },
+
+  /**
    * Returns whether the entity needs trigger the stop action
    * before having any further actions added to its motion queue
    * @return {boolean}
@@ -610,7 +633,7 @@ MotionManager.prototype = {
   isRequiredToStopBeforeFurtherAction() {
     return (
       this.isMoving() &&
-      !this.isEntityFacingTarget() &&
+      !this.isEntityFacingTargetRoughly() &&
       this.entity.hasSlowManeuverability()
     );
   },


### PR DESCRIPTION
## Issue
#446 

## Solution
Removed restriction for slow units so that they don't have to stop when changing directions unless the angle between them and the target is greater than 90 degrees. 

## Test
Manual tests