### PR TITLE
#448 Remove constant update of coordinates in GetInRange

### DIFF
--- a/src/js/entities/activities/GetInRange.js
+++ b/src/js/entities/activities/GetInRange.js
@@ -57,10 +57,7 @@ class GetInRange extends Move {
     ) {
       this.entity.stop();
       this.kill();
-      return;
     }
-
-    this.moveTowardsTarget();
   }
 
   /**
@@ -70,22 +67,6 @@ class GetInRange extends Move {
   activate() {
     this.setCoordsToTarget();
     super.activate();
-  }
-
-  /**
-   * Move towards the target entity
-   * @return {void}
-   */
-  moveTowardsTarget() {
-    if (
-      this.coords.x === this.target.getSprite().x &&
-      this.coords.y === this.target.getSprite().y
-    ) {
-      return;
-    }
-
-    this.setCoordsToTarget();
-    this.entity.getMotionManager().moveTo(this);
   }
 
   /**


### PR DESCRIPTION
## Prelude
`GetInRange` activity updates coordinates of the target at every tick causing EasyStarJs to recalculate the route so many times the entity begins to attempt to rotate all over the place. 

## Issue
#448 

## Solution
`GetInRange` sets the coordinates only during activation.

## Test
Manual test