### PR TITLE
#455 increse size of the buildings and space objects

### DIFF
--- a/src/js/entities/Entity.js
+++ b/src/js/entities/Entity.js
@@ -31,8 +31,10 @@ function getEntityDimensionsForVisitingTiles(sprite, dataObject) {
   let height = 1;
 
   if (isBuilding) {
-    width = Math.max(Math.floor(sprite.hitArea.width / Const.TILE_WIDTH), 1);
-    height = Math.max(Math.floor(sprite.hitArea.height / Const.TILE_HEIGHT), 1);
+    width =
+      Math.max(Math.floor(sprite.hitArea.width / Const.TILE_WIDTH), 1) + 1;
+    height =
+      Math.max(Math.floor(sprite.hitArea.height / Const.TILE_HEIGHT), 1) + 1;
   }
 
   return {

--- a/src/js/map/CollisionMap.js
+++ b/src/js/map/CollisionMap.js
@@ -9,9 +9,9 @@ const ns = window.fivenations;
 const ACCEPTABLE_TILES = [0];
 
 // various types of obstacles
-const OBSTACLE_BUILDING = 0;
-const OBSTACLE_ENTITY = 1;
-const OBSTACLE_SPACE_OBJECT = 2;
+const OBSTACLE_BUILDING = 1;
+const OBSTACLE_ENTITY = 2;
+const OBSTACLE_SPACE_OBJECT = 3;
 
 /**
  * Returns an object that contains collision informations for
@@ -316,28 +316,31 @@ class CollisionMap {
     }
 
     // shows the tile where the leading collision point is located
-    entityManager.entities(':not(hibernated)').forEach((entity) => {
-      const tiles = entity.getTilesAhead();
-      const width = TILE_WIDTH;
-      const height = TILE_HEIGHT;
+    entityManager
+      .entities(':not(hibernated)')
+      .filter(entity => !entity.getDataObject().isBuilding())
+      .forEach((entity) => {
+        const tiles = entity.getTilesAhead();
+        const width = TILE_WIDTH;
+        const height = TILE_HEIGHT;
 
-      tiles.forEach((tile) => {
-        const x = tile.x * width;
-        const y = tile.y * height;
-        const rect = new Phaser.Rectangle(x, y, width, height);
-        phaserGame.debug.geom(rect, '#ffac00', false);
-      });
-
-      const pathTiles = entity.getTilesToTarget();
-      if (pathTiles) {
-        pathTiles.forEach((tile) => {
+        tiles.forEach((tile) => {
           const x = tile.x * width;
           const y = tile.y * height;
           const rect = new Phaser.Rectangle(x, y, width, height);
-          phaserGame.debug.geom(rect, '#00ab00', false);
+          phaserGame.debug.geom(rect, '#ffac00', false);
         });
-      }
-    });
+
+        const pathTiles = entity.getTilesToTarget();
+        if (pathTiles) {
+          pathTiles.forEach((tile) => {
+            const x = tile.x * width;
+            const y = tile.y * height;
+            const rect = new Phaser.Rectangle(x, y, width, height);
+            phaserGame.debug.geom(rect, '#00ab00', false);
+          });
+        }
+      });
   }
 
   /**

--- a/src/js/sync/Entity.Create.js
+++ b/src/js/sync/Entity.Create.js
@@ -20,6 +20,8 @@ EntityCreate.prototype.execute = (options) => {
     return;
   }
   const config = options.data;
+  // creates and augments the EntityManager with a new entity that
+  // is generated based on the given configuration object
   ns.game.entityManager.add(config);
 };
 


### PR DESCRIPTION
## Prelude
Collision Tiles of Buildings and Space Objects are not big enough to form massive barriers for entities that results in unnecessary usage of multiple objects in the same area.

## Issue
#455 

## Solution
Increased the sizes of `Buildings` and `Space Objects` by one row and column.

## Test
Manual tests